### PR TITLE
Fix CVE-2014-9680, CVE-2013-1775, CVE-2013-1776

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -119,6 +119,26 @@ fi
 ])dnl
 
 dnl
+dnl Detect time zone file directory, if any.
+dnl
+AC_DEFUN([SUDO_TZDIR], [AC_MSG_CHECKING(time zone data directory)
+tzdir="$with_tzdir"
+if test -z "$tzdir"; then
+    tzdir=no
+    for d in /usr/share /usr/share/lib /usr/lib /etc; do
+	if test -d "$d/zoneinfo"; then
+	    tzdir="$d/zoneinfo"
+	    break
+	fi
+    done
+fi
+AC_MSG_RESULT([$tzdir])
+if test "${tzdir}" != "no"; then
+    SUDO_DEFINE_UNQUOTED(_PATH_ZONEINFO, "$tzdir")
+fi
+])dnl
+
+dnl
 dnl Where the timestamp files go.
 dnl
 AC_DEFUN([SUDO_TIMEDIR], [AC_MSG_CHECKING(for timestamp file location)

--- a/configure
+++ b/configure
@@ -847,6 +847,7 @@ with_badpass_message
 with_fqdn
 with_timedir
 with_iologdir
+with_tzdir
 with_sendmail
 with_sudoers_mode
 with_sudoers_uid
@@ -1628,6 +1629,7 @@ Optional Packages:
   --with-fqdn             expect fully qualified hosts in sudoers
   --with-timedir          path to the sudo timestamp dir
   --with-iologdir=DIR     directory to store sudo I/O log files in
+  --with-tzdir=DIR        path to the time zone data directory
   --with-sendmail         set path to sendmail
   --without-sendmail      do not send mail at all
   --with-sudoers-mode     mode of sudoers file (defaults to 0440)
@@ -4659,6 +4661,16 @@ if test "${with_iologdir+set}" = set; then :
     yes)    ;;
     no)     as_fn_error $? "\"--without-iologdir not supported.\"" "$LINENO" 5
 	    ;;
+esac
+fi
+
+
+
+# Check whether --with-tzdir was given.
+if test "${with_tzdir+set}" = set; then :
+  withval=$with_tzdir; case $with_tzdir in
+    yes)	as_fn_error $? "\"must give --with-tzdir an argument.\"" "$LINENO" 5
+		;;
 esac
 fi
 
@@ -23312,5 +23324,26 @@ fi
 
 
 
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking time zone data directory" >&5
+$as_echo_n "checking time zone data directory... " >&6; }
+tzdir="$with_tzdir"
+if test -z "$tzdir"; then
+    tzdir=no
+    for d in /usr/share /usr/share/lib /usr/lib /etc; do
+	if test -d "$d/zoneinfo"; then
+	    tzdir="$d/zoneinfo"
+	    break
+	fi
+    done
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $tzdir" >&5
+$as_echo "$tzdir" >&6; }
+if test "${tzdir}" != "no"; then
+    cat >>confdefs.h <<EOF
+#define _PATH_ZONEINFO "$tzdir"
+EOF
+
+fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -774,6 +774,12 @@ AC_ARG_WITH(iologdir, [AS_HELP_STRING([--with-iologdir=DIR], [directory to store
 	    ;;
 esac])
 
+AC_ARG_WITH(tzdir, [AS_HELP_STRING([--with-tzdir=DIR], [path to the time zone data directory])],
+[case $with_tzdir in
+    yes)	AC_MSG_ERROR(["must give --with-tzdir an argument."])
+		;;
+esac])
+
 AC_ARG_WITH(sendmail, [AS_HELP_STRING([--with-sendmail], [set path to sendmail])
 AS_HELP_STRING([--without-sendmail], [do not send mail at all])],
 [case $with_sendmail in
@@ -3240,6 +3246,7 @@ fi
 SUDO_LOGFILE
 SUDO_TIMEDIR
 SUDO_IO_LOGDIR
+SUDO_TZDIR
 
 dnl
 dnl Turn warnings into errors.

--- a/pathnames.h.in
+++ b/pathnames.h.in
@@ -168,3 +168,7 @@
 #ifndef _PATH_NETSVC_CONF
 #undef	_PATH_NETSVC_CONF
 #endif /* _PATH_NETSVC_CONF */
+
+#ifndef _PATH_ZONEINFO
+# undef        _PATH_ZONEINFO
+#endif /* _PATH_ZONEINFO */

--- a/plugins/sudoers/check.c
+++ b/plugins/sudoers/check.c
@@ -82,6 +82,7 @@ static struct tty_info {
     dev_t rdev;			/* tty device ID */
     ino_t ino;			/* tty inode number */
     struct timeval ctime;	/* tty inode change time */
+    pid_t sid;			/* ID of session with controlling tty */
 } tty_info;
 
 static int   build_timestamp(char **, char **);
@@ -138,13 +139,14 @@ check_user(int validated, int mode)
     if (ISSET(mode, MODE_IGNORE_TICKET))
 	SET(validated, FLAG_CHECK_USER);
 
-    /* Stash the tty's ctime for tty ticket comparison. */
+    /* Stash the tty's device, session ID and ctime for ticket comparison. */
     if (def_tty_tickets && user_ttypath && stat(user_ttypath, &sb) == 0) {
 	tty_info.dev = sb.st_dev;
 	tty_info.ino = sb.st_ino;
 	tty_info.rdev = sb.st_rdev;
 	if (tty_is_devpts(user_ttypath))
 	    ctim_get(&sb, &tty_info.ctime);
+	tty_info.sid = user_sid;
     }
 
     if (build_timestamp(&timestampdir, &timestampfile) == -1) {

--- a/plugins/sudoers/check.c
+++ b/plugins/sudoers/check.c
@@ -627,31 +627,34 @@ timestamp_status(char *timestampdir, char *timestampfile, char *user, int flags)
      */
     if (status == TS_OLD && !ISSET(flags, TS_REMOVE)) {
 	mtim_get(&sb, &mtime);
-	/* Negative timeouts only expire manually (sudo -k). */
-	if (def_timestamp_timeout < 0 && mtime.tv_sec != 0)
-	    status = TS_CURRENT;
-	else {
-	    now = time(NULL);
-	    if (def_timestamp_timeout &&
-		now - mtime.tv_sec < 60 * def_timestamp_timeout) {
-		/*
-		 * Check for bogus time on the stampfile.  The clock may
-		 * have been set back or someone could be trying to spoof us.
-		 */
-		if (mtime.tv_sec > now + 60 * def_timestamp_timeout * 2) {
-		    time_t tv_sec = (time_t)mtime.tv_sec;
-		    log_error(0,
-			_("timestamp too far in the future: %20.20s"),
-			4 + ctime(&tv_sec));
-		    if (timestampfile)
-			(void) unlink(timestampfile);
-		    else
-			(void) rmdir(timestampdir);
-		    status = TS_MISSING;
-		} else if (get_boottime(&boottime) && timevalcmp(&mtime, &boottime, <)) {
-		    status = TS_OLD;
-		} else {
-		    status = TS_CURRENT;
+	if (timevalisset(&mtime)) {
+	    /* Negative timeouts only expire manually (sudo -k). */
+	    if (def_timestamp_timeout < 0) {
+		status = TS_CURRENT;
+	    } else {
+		now = time(NULL);
+		if (def_timestamp_timeout &&
+		    now - mtime.tv_sec < 60 * def_timestamp_timeout) {
+		    /*
+		     * Check for bogus time on the stampfile.  The clock may
+		     * have been set back or user could be trying to spoof us.
+		     */
+		    if (mtime.tv_sec > now + 60 * def_timestamp_timeout * 2) {
+			time_t tv_sec = (time_t)mtime.tv_sec;
+			log_error(0,
+			    _("timestamp too far in the future: %20.20s"),
+			    4 + ctime(&tv_sec));
+			if (timestampfile)
+			    (void) unlink(timestampfile);
+			else
+			    (void) rmdir(timestampdir);
+			status = TS_MISSING;
+		    } else if (get_boottime(&boottime) &&
+			timevalcmp(&mtime, &boottime, <)) {
+			status = TS_OLD;
+		    } else {
+			status = TS_CURRENT;
+		    }
 		}
 	    }
 	}

--- a/plugins/sudoers/sudoers.c
+++ b/plugins/sudoers/sudoers.c
@@ -1410,6 +1410,10 @@ deserialize_info(char * const args[], char * const settings[], char * const user
 	    sudo_user.cols = atoi(*cur + sizeof("cols=") - 1);
 	    continue;
 	}
+	if (MATCHES(*cur, "sid=")) {
+	    sudo_user.sid = atoi(*cur + sizeof("sid=") - 1);
+	    continue;
+	}
     }
     if (user_cwd == NULL)
 	user_cwd = "unknown";

--- a/plugins/sudoers/sudoers.h
+++ b/plugins/sudoers/sudoers.h
@@ -95,6 +95,7 @@ struct sudo_user {
     int   flags;
     uid_t uid;
     uid_t gid;
+    pid_t sid;
 };
 
 /*
@@ -171,8 +172,8 @@ struct sudo_user {
 #define user_name		(sudo_user.name)
 #define user_uid		(sudo_user.uid)
 #define user_gid		(sudo_user.gid)
+#define user_sid		(sudo_user.sid)
 #define user_passwd		(sudo_user.pw->pw_passwd)
-#define user_uuid		(sudo_user.uuid)
 #define user_dir		(sudo_user.pw->pw_dir)
 #define user_gids		(sudo_user.gids)
 #define user_ngids		(sudo_user.ngids)


### PR DESCRIPTION
CVE-2014-9680: unsafe handling of TZ environment variable.
CVE-2013-1775: authentication bypass when the clock is set to the UNIX epoch [00:00:00 UTC on 1 January 1970]
CVE-2013-1776: session id hijacking from another authorized tty
